### PR TITLE
Fix duplicate IDs in split/merge function examples

### DIFF
--- a/function-RTP-merger.json
+++ b/function-RTP-merger.json
@@ -15,7 +15,7 @@
       },
       {
         "name": "merge-number",
-        "id": 12,
+        "id": 2,
         "datatype": "integer",
         "values": [
           {

--- a/function-RTP-splitter.json
+++ b/function-RTP-splitter.json
@@ -15,7 +15,7 @@
       },
       {
         "name": "split-number",
-        "id": 12,
+        "id": 2,
         "datatype": "integer",
         "values": [
           {


### PR DESCRIPTION
The ID 12 was duplicated in the parameters.