### PR TITLE
Change priority to be an unsigned integer

### DIFF
--- a/nbmp-schema-definitions.json
+++ b/nbmp-schema-definitions.json
@@ -37,7 +37,10 @@
         "type": "string",
         "format": "date-time"
       },
-      "priority": {"type": "number"},
+      "priority": {
+        "type": "integer",
+        "minimum": 0
+      },
       "location": {"type": "string"},
       "task-group": {
         "type": "array",


### PR DESCRIPTION
In Table 53 `priority` is defined as `unsigned integer`.

Maybe this changed for the 2nd edition, but I assume this did not as `priority` properties in other descriptors are defined that way.