### PR TITLE
Change stream-id to be optional for bind objects

### DIFF
--- a/nbmp-schema-definitions.json
+++ b/nbmp-schema-definitions.json
@@ -82,7 +82,7 @@
             "port-name": {"type": "string"},
             "bind": {
               "type": "object",
-              "required": ["stream-id", "name"],
+              "required": ["name"],
               "properties": {
                 "stream-id": {"type": "string"},
                 "name": {"type": "string"},
@@ -108,7 +108,7 @@
             "port-name": {"type": "string"},
             "bind": {
               "type": "object",
-              "required": ["stream-id", "name"],
+              "required": ["name"],
               "properties": {
                 "stream-id": {"type": "string"},
                 "name": {"type": "string"},


### PR DESCRIPTION
In Table 14, `stream-id` is defined as optional. My understanding is that function descriptions would not set this field.

This may have changed for the 2nd edition, but I assume this did not, as I don't know what value this would take for function descriptions.