### PR TITLE
Change schema type to object to allow for JSON schema definitions

### DIFF
--- a/nbmp-schema-definitions.json
+++ b/nbmp-schema-definitions.json
@@ -812,9 +812,9 @@
               "then": {
                 "requires": ["schema"],
                 "properties": {
-                  "schema": {"type": "array"}
-                } 
-              } 
+                  "schema": {"type": "object"}
+                }
+              }
             }
           ]
         }


### PR DESCRIPTION
If the `function-RTP-splitter.json` and `function-RTP-merger.json` examples are correct, the `schema` property should be an `object`. As this should specify the JSON schema, this also makes more sense to me.